### PR TITLE
Add htmllib2 as a hard dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+0.1.2 (unreleased)
+------------------
+
+- Added ``httplib2`` as a dependency.
+
 0.1.1 (2010-12-10)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     author_email='rob@cogit8.org',
     url='http://github.com/robhudson/pivotal-py/',
     packages=['pivotal'],
+    install_requires=['httplib2'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
Packages specifying pivotal-py as a dependency fail to install unless htmllib2 is already available.
