### PR TITLE
Prevent circular import of httplib2 before it can be installed with distribute/setuptools.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+0.1.3 (unreleased)
+------------------
+
+- Prevent circular import of httplib2 before it can be installed with
+  distribute/setuptools.
+
 0.1.2 (2011-07-8)
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open('README.rst').read() + open('CHANGES.rst').read()
 
 setup(
     name='pivotal-py',
-    version=__import__('pivotal').__version__,
+    version='0.1.2',
     description='Thin client for Pivotal Tracker\'s API',
     long_description=long_description,
     author='Rob Hudson',


### PR DESCRIPTION
Sorry, I misdiagnosed the problem causing the install to fail. It was due to a circular import of httplib2 when finding the version number for the setup.py script. This should _really_ fix the issue (or at least it installs properly locally).
