### PR TITLE
Enable HTTPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ token.
 Once you have an API token making requests against the APIs follows a simple
 pattern of chainable methods, for example::
 
-    from pivotal import Pivotal
+    from pivotal.pivotal import Pivotal
     
     pv = Pivotal('TOKEN')
     

--- a/pivotal/pivotal.py
+++ b/pivotal/pivotal.py
@@ -4,22 +4,26 @@ import httplib2
 from urllib import urlencode
 
 
-BASE_URL = 'http://www.pivotaltracker.com/services/v3/'
-
+BASE_URL = 'www.pivotaltracker.com/services/v3/'
+PROTO_SWITCH = {
+    True: 'https://',
+    False: 'http://'
+}
 
 class Pivotal(object):
 
-    def __init__(self, token):
+    def __init__(self, token, use_https=True):
         self.token = token
         self.path = []
         self.qs = {}
+        self.use_https = bool(use_https)
 
     def __getattr__(self, method):
         # Create a new copy of self
-        obj = self.__class__(self.token)
+        obj = self.__class__(self.token, self.use_https)
         obj.path = copy.copy(self.path)
         obj.qs = copy.copy(self.qs)
-
+        
         obj.path.append(method)
         return obj.mock_attr
 
@@ -36,7 +40,7 @@ class Pivotal(object):
 
     @property
     def url(self):
-        url = BASE_URL + '/'.join(map(str, self.path))
+        url = PROTO_SWITCH[self.use_https] + BASE_URL + '/'.join(map(str, self.path))
         if self.qs:
             url += '?' + urlencode(self.qs)
         return url

--- a/pivotal/tests.py
+++ b/pivotal/tests.py
@@ -1,19 +1,32 @@
 import unittest
 
-from pivotal import Pivotal, BASE_URL
+from pivotal import Pivotal, BASE_URL, PROTO_SWITCH
 
 class PivotalTest(unittest.TestCase):
 
-    def test_url_strings(self):
-        pv = Pivotal('ABCDEF')
+    def test_protocol_switch(self):
+        self.assertEqual(PROTO_SWITCH[True], 'https://')
+        self.assertEqual(PROTO_SWITCH[False], 'http://')
 
-        self.assertEqual(pv.projects().url, BASE_URL + 'projects')
-        self.assertEqual(pv.projects(123).url, BASE_URL + 'projects/123')
-        self.assertEqual(pv.projects('123').url, BASE_URL + 'projects/123')
+
+    def _test_url_strings(self, use_https):
+        pv = Pivotal('ABCDEF', use_https=use_https)
+
+        url = PROTO_SWITCH[use_https] + BASE_URL
+        
+        self.assertEqual(pv.projects().url, url + 'projects')
+        self.assertEqual(pv.projects(123).url, url + 'projects/123')
+        self.assertEqual(pv.projects('123').url, url + 'projects/123')
         self.assertEqual(pv.projects('123').stories().url, 
-                         BASE_URL + 'projects/123/stories')
+                      url + 'projects/123/stories')
         self.assertEqual(pv.projects('123').stories(filter='state:unstarted').url,
-                         BASE_URL + 'projects/123/stories?filter=state%3Aunstarted')
+                      url + 'projects/123/stories?filter=state%3Aunstarted')
+
+    def test_https_urls(self):
+        self._test_url_strings(use_https=True)
+
+    def test_http_urls(self):
+        self._test_url_strings(use_https=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PivotalTracker projects can be set to require SSL for API access.

Note that this does change the default behavior of any Pivotal instances to use https, which seems like a safer default anyway.
