### PR TITLE
Make base URL pluggable

### DIFF
--- a/pivotal/pivotal.py
+++ b/pivotal/pivotal.py
@@ -13,6 +13,7 @@ PROTO_SWITCH = {
 class Pivotal(object):
 
     def __init__(self, token, use_https=True):
+        self.base_url = BASE_URL
         self.token = token
         self.path = []
         self.qs = {}
@@ -40,7 +41,7 @@ class Pivotal(object):
 
     @property
     def url(self):
-        url = PROTO_SWITCH[self.use_https] + BASE_URL + '/'.join(map(str, self.path))
+        url = PROTO_SWITCH[self.use_https] + self.base_url + '/'.join(map(str, self.path))
         if self.qs:
             url += '?' + urlencode(self.qs)
         return url


### PR DESCRIPTION
Hey Rob...  Happy new year ;) 

I've been playing with the PT API and v4 is in alpha now which prompted me to make the API URL pluggable. Not sure if you favor more complication to support an argument like `pt = Pivotal(TOKEN, v=4)` or even making the URL a kwarg? But this get's the job done for me and I figure you'll just bump the base to v4 when it's officially supported anyway.
